### PR TITLE
ISD Flow / Needs Analysis page

### DIFF
--- a/isd-app/src/App.jsx
+++ b/isd-app/src/App.jsx
@@ -1,69 +1,68 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import {
-	Home,
-	LogIn,
-	SignUp,
-	Request,
-	CourseRequest,
-	AccountSetUpEmail,
-	AccountSetUpNamePassword,
-	AccountSetUpCompanyName,
-	Users,
-	Error,
-	TeamMembers,
-} from './pages';
-import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
-import { useGetAuthStatusQuery } from './redux/RTKQueries/authQuery';
-import { logIn, logOut } from './redux/slices/authSlice';
+  Home,
+  LogIn,
+  SignUp,
+  Request,
+  CourseRequest,
+  AccountSetUpEmail,
+  AccountSetUpNamePassword,
+  AccountSetUpCompanyName,
+  Users,
+  Error,
+  TeamMembers,
+  ISDFlowNeedsAnalysis,
+} from "./pages";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { useGetAuthStatusQuery } from "./redux/RTKQueries/authQuery";
+import { logIn, logOut } from "./redux/slices/authSlice";
 
 function App() {
-	const dispatch = useDispatch();
-	const { data, error } = useGetAuthStatusQuery();
+  const dispatch = useDispatch();
+  const { data, error } = useGetAuthStatusQuery();
 
-	useEffect(() => {
-		// Check the authentication status
-		if (data) {
-			dispatch(logIn());
-		}
+  useEffect(() => {
+    // Check the authentication status
+    if (data) {
+      dispatch(logIn());
+    }
 
-		if (error) {
-			dispatch(logOut());
-		}
-	}, [data, error, dispatch]);
+    if (error) {
+      dispatch(logOut());
+    }
+  }, [data, error, dispatch]);
 
-	return (
-		<Router>
-			<Routes>
-				<Route path='/' element={<Home />} />
-				<Route path='/login' element={<LogIn />} />
-				<Route path='/signup' element={<SignUp />} />
-				<Route path='/request' element={<Request />} />
-				<Route path='/courserequest' element={<CourseRequest />} />
-				<Route
-					path='/accountsetup/email'
-					element={<AccountSetUpEmail />}
-				/>
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<LogIn />} />
+        <Route path="/signup" element={<SignUp />} />
+        <Route path="/request" element={<Request />} />
+        <Route path="/courserequest" element={<CourseRequest />} />
+        <Route path="/accountsetup/email" element={<AccountSetUpEmail />} />
 
-				<Route path='/members' element={<TeamMembers />} />
+        <Route path="/members" element={<TeamMembers />} />
 
-				<Route
-					path='/accountsetup/name_password'
-					element={<AccountSetUpNamePassword />}
-				/>
-				<Route
-					path='/accountsetup/company_name'
-					element={<AccountSetUpCompanyName />}
-				/>
-				<Route path='/accountsetup/users' element={<Users />} />
-				<Route
-					path='/accountsetup/email'
-					element={<AccountSetUpEmail />}
-				/>
-				<Route path='*' element={<Error />} />
-			</Routes>
-		</Router>
-	);
+        <Route
+          path="/accountsetup/name_password"
+          element={<AccountSetUpNamePassword />}
+        />
+        <Route
+          path="/accountsetup/company_name"
+          element={<AccountSetUpCompanyName />}
+        />
+        <Route path="/accountsetup/users" element={<Users />} />
+        <Route path="/accountsetup/email" element={<AccountSetUpEmail />} />
+        <Route
+          path="/isdflow/needsanalysis"
+          element={<ISDFlowNeedsAnalysis />}
+        />
+        <Route path="*" element={<Error />} />
+      </Routes>
+    </Router>
+  );
 }
 
 export default App;

--- a/isd-app/src/assets/icons/tick-circle-solid.svg
+++ b/isd-app/src/assets/icons/tick-circle-solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 15 15">
+<path fill="#2a7b0d" fill-rule="evenodd" d="M0 7.5a7.5 7.5 0 1 1 15 0a7.5 7.5 0 0 1-15 0m7.072 3.21l4.318-5.398l-.78-.624l-3.682 4.601L4.32 7.116l-.64.768z" clip-rule="evenodd"/>
+</svg>

--- a/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.jsx
+++ b/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.jsx
@@ -1,0 +1,182 @@
+import "./NeedsAnalysis.scss";
+import { useForm } from "react-hook-form";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+import ISDFlowPage from "../../../utilities/isdPagesLogic/isdFlowPage/ISDFlowPage";
+import { MyInput, MyTextArea } from "../../../utilities/utils";
+
+const errorSchema = yup.object({}).required();
+
+const submitNeedsAnalysisForm = async (data) => {
+  console.log(data);
+};
+
+const NeedsAnalysisForm = ({ currentStep }) => {
+  const { register, handleSubmit } = useForm({
+    resolver: yupResolver(errorSchema),
+  });
+
+  return (
+    <form
+      className="isd-flow-form"
+      onSubmit={handleSubmit(submitNeedsAnalysisForm)}
+    >
+      <h3 className="form-title">{currentStep}</h3>
+      <fieldset>
+        <div className="field-title">Purpose</div>
+        <div className="field-text">
+          This document supports academic needs analysis (reduced) as well as
+          organizational (expanded). You must understand the problem this course
+          addresses. Organizational learning analysis are more involved{" "}
+          <span>show more</span>.
+        </div>
+      </fieldset>
+      <fieldset>
+        <div className="field-title">Quality Criteria</div>
+        <div className="field-text">
+          1. The problem is clearly stated and fully understood by the design
+          team.
+          <br />
+          2. We have credible data confirming the extent of the problem (applies
+          primarily to organizational) <span>show more</span>.
+        </div>
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="stakeholder"
+          type="input"
+          label="Stakeholder"
+          value="Thomas Garrod"
+          disabled
+          {...register("stakeholder")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="problem_statement"
+          type="input"
+          label="Problem Statement"
+          value="Inventory management workflow breaking issue"
+          disabled
+          {...register("problem_statement")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="problem_data"
+          type="input"
+          label="Problem Data"
+          {...register("problem_data")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="success_statement"
+          type="input"
+          label="Success Statement"
+          {...register("success_statement")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyTextArea
+          name="audience_definition"
+          label="Audience Definition"
+          rows="4"
+          placeholder="Enter audience definition..."
+          {...register("audience_definition")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyTextArea
+          name="audience_benefit"
+          label="Audience Benefit"
+          rows="4"
+          placeholder="Enter audience benefit..."
+          {...register("audience_benefit")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyTextArea
+          name="audience_needs"
+          label="Audience Needs"
+          rows="4"
+          placeholder="Enter audience needs..."
+          {...register("audience_needs")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="change_issues"
+          type="input"
+          label="Change Issues"
+          {...register("change_issues")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="technology_issues"
+          type="input"
+          label="Technology Issuess"
+          {...register("technology_issues")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="proof_of_consumption"
+          type="input"
+          label="Proof of Consumption"
+          {...register("proof_of_consumption")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="potential_for_change"
+          type="input"
+          label="Potential for Change"
+          {...register("potential_for_change")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="delivery_strategy"
+          type="input"
+          label="Delivery Strategy"
+          {...register("delivery_strategy")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="project_risks"
+          type="input"
+          label="Project Risks"
+          {...register("project_risks")}
+        />
+      </fieldset>
+      <fieldset>
+        <MyInput
+          name="recommendation"
+          type="input"
+          label="Recommendation"
+          placeholder="Inventory management workflow breaking issue"
+          {...register("recommendation")}
+        />
+      </fieldset>
+      <div className="button-container">
+        <button className="button next">Next</button>
+        <button className="button cancel">Cancel</button>
+      </div>
+    </form>
+  );
+};
+
+const NeedsAnalysis = () => {
+  const currentStep = "Needs Analysis";
+
+  return (
+    <ISDFlowPage currentStep={currentStep}>
+      <NeedsAnalysisForm currentStep={currentStep} />
+    </ISDFlowPage>
+  );
+};
+
+export default NeedsAnalysis;

--- a/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.scss
+++ b/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.scss
@@ -1,0 +1,81 @@
+@import '../../../styles/variables';
+
+.isd-flow-form {
+    padding: 2rem 1.5rem 3rem;
+    background-color: $form-white-background;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+
+    .form-title {
+        font-size: $font-size-regular;
+        font-weight: $fontWeightSemiBold;
+    }
+
+    .field-title {
+        font-weight: $fontWeightSemiBold;
+        font-size: $font-size-small;
+        margin-bottom: 1rem;
+    }
+
+    .field-text {
+        font-size: $font-size-semi-small;
+        font-weight: $fontWeightRegular;
+        color: $font-color-darker-grey;
+
+        span {
+            font-weight: $fontWeightBold;
+        }
+    }
+
+    .form-input {
+        label {
+            font-size: $font-size-semi-small;
+            font-weight: $fontWeightMedium;
+            margin-bottom: 0.5rem;
+        }
+
+        input, textarea {
+            width: 100%;
+			border: 1px solid var(--Black-20, rgba(17, 17, 19, 0.2));
+			box-sizing: border-box;
+			font-weight: $fontWeightRegular;
+			font-size: $font-size-small;
+        }
+
+        input {
+            border-radius: 0.25rem;
+			min-height: 3rem;
+			height: 100%;
+            padding: 0.8125rem 1rem;
+        }
+
+        input:disabled{
+            color: $font-color-one-more-grey;
+        }
+
+        textarea {
+            border-radius: 0.5rem;
+            padding: 0.625rem 0.875rem;
+            resize: none;
+        }
+    }
+
+    .button-container {
+        .button {
+            float: right;
+            padding: 1rem 1.5rem;
+            cursor: pointer;
+            border-radius: 0;
+            font-weight: $fontWeightBold;
+            font-size: $font-size-small;
+        }
+        .cancel {
+            background-color: $form-white-background;
+        }
+        .next {
+            color: $font-color-white;
+            background-color: $button-blue-background;
+        }
+    }
+}

--- a/isd-app/src/pages/index.js
+++ b/isd-app/src/pages/index.js
@@ -9,3 +9,4 @@ export { default as AccountSetUpCompanyName } from './AccountSetUp/CompanyName/C
 export { default as Users } from './AccountSetUp/Users/Users';
 export { default as Error } from './Error/Error';
 export { default as TeamMembers } from './TeamMembers/TeamMembers';
+export { default as ISDFlowNeedsAnalysis} from './ISDFlow/NeedsAnalysis/NeedsAnalysis';

--- a/isd-app/src/styles/_formstyles.scss
+++ b/isd-app/src/styles/_formstyles.scss
@@ -1,7 +1,7 @@
 @import './variables';
 
 .form-container {
-	color: #000;
+	color: $font-color-black;
 	font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
 	height: 100vh;
 	width: 100vw;

--- a/isd-app/src/styles/_variables.scss
+++ b/isd-app/src/styles/_variables.scss
@@ -11,8 +11,10 @@ $fontWeightRegular: 400;
 $font-size-large: 3rem;
 $font-size-medium: 2rem;
 $font-size-regular: 1.5rem;
+$font-size-half-regular: 1.25rem;
 $font-size-semi-regular: 1.125rem;
 $font-size-small: 1rem;
+$font-size-semi-small: 0.875rem;
 $font-size-extra-small: 0.75rem;
 
 @font-face {
@@ -55,8 +57,15 @@ $default-background: #f6f8fa;
 $form-white-background: #fff;
 $button-blue-background: #0774c3;
 $button-purple-background: var(--Brand-50, #f9f5ff);
+$current-menu-step-background: #A4C8FF;
+$next-menu-step-background:#F2F2F2;
+$completed-menu-step-background: #fff;
 
 //font Colors
 $font-color-white: #fff;
 $font-color-grey: #767676;
 $font-color-purple: var(--Brand-700, #6941c6);
+$font-color-black: #000;
+$font-color-darker-grey: #5C5C5C;
+$font-color-one-more-grey: var(--Black-40, 
+rgba(17, 17, 19, 0.4));

--- a/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.jsx
+++ b/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.jsx
@@ -1,0 +1,21 @@
+import "./ISDFlowPage.scss";
+import StepsMenu from "../stepsMenu/StepsMenu";
+import ProjectInfo from "../projectInfo/ProjectInfo";
+
+const ISDFlowPage = ({ currentStep, children }) => {
+  //TODO: need to retrieve course name from backend side
+  const courseName = "Reducing issues in manufacturing workflow";
+
+  return (
+    <div className="isd-flow-container">
+      <h3 className="isd-flow-title">Course name: {courseName}</h3>
+      <div className="isd-flow-content">
+        <StepsMenu currentStep={currentStep} />
+        <div className="isd-flow-form-container">{children}</div>
+        <ProjectInfo />
+      </div>
+    </div>
+  );
+};
+
+export default ISDFlowPage;

--- a/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.scss
+++ b/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.scss
@@ -1,0 +1,28 @@
+@import '../../../styles/variables';
+
+.isd-flow-container {
+    display: flex;
+    color: $font-color-black;
+    flex-direction: column;
+    padding: 3rem 5rem;
+    font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
+	height: 100%;
+	width: 100vw;
+    background-color: $default-background;
+    gap: 2.1875rem;
+
+    .isd-flow-title {
+        font-weight: $fontWeightBold;
+        font-size: $font-size-large;
+    }
+
+    .isd-flow-content {
+        display: flex;
+        gap: 1.25rem;
+
+        .isd-flow-form-container {
+            flex: 0 1 55%;
+        }
+    }
+}
+

--- a/isd-app/src/utilities/isdPagesLogic/projectInfo/ProjectInfo.jsx
+++ b/isd-app/src/utilities/isdPagesLogic/projectInfo/ProjectInfo.jsx
@@ -1,0 +1,34 @@
+import "./ProjectInfo.scss";
+
+const InfoBlock = ({ title, content }) => {
+  return (
+    <li key={title} className="info-block">
+      <div className="title">{title}</div>
+      <div className="content">{content}</div>
+    </li>
+  );
+};
+const ProjectInfo = () => {
+  //TODO: Need to retrieve the project info from the backend
+  const INFO = [
+    { "Project ID": "ID13405GE3045" },
+    { "Delivery Date": "September 30, 2023" },
+    { Stakeholder: "Thomas Garrod" },
+    { "Subject Matter Expert": "Gagan Gundyadka" },
+    { "Instructional System Designer": "Irina Lavrova" },
+    { "Quality Assurance": "Lei Lei" },
+  ];
+
+  const info = INFO.map((item) => {
+    const title = Object.keys(item)[0];
+    return <InfoBlock title={title} content={item[title]} />;
+  });
+
+  return (
+    <div className="isd-flow-project-info-container">
+      <ul className="isd-flow-project-info">{info}</ul>
+    </div>
+  );
+};
+
+export default ProjectInfo;

--- a/isd-app/src/utilities/isdPagesLogic/projectInfo/ProjectInfo.scss
+++ b/isd-app/src/utilities/isdPagesLogic/projectInfo/ProjectInfo.scss
@@ -1,0 +1,27 @@
+@import '../../../styles/variables';
+
+.isd-flow-project-info-container {
+    flex: 0 1 20%;
+
+    .isd-flow-project-info {
+        display: flex;
+        flex-direction: column;
+        background-color: $form-white-background;
+        gap: 2rem;
+        padding: 1.25rem;
+
+        .info-block {
+            list-style-type: none;
+            .title {
+                color: $font-color-darker-grey;
+                font-weight: $fontWeightRegular;
+                font-size: $font-size-semi-small;
+            }
+            .content {
+                color: $font-color-black;
+                font-weight: $fontWeightSemiBold;
+                font-size: $font-size-small;
+            }
+        }
+    }
+}

--- a/isd-app/src/utilities/isdPagesLogic/stepsMenu/StepsMenu.jsx
+++ b/isd-app/src/utilities/isdPagesLogic/stepsMenu/StepsMenu.jsx
@@ -1,0 +1,45 @@
+import "./StepsMenu.scss";
+import TickCircleSolid from "../../../assets/icons/tick-circle-solid.svg";
+
+const MENU_STEPS = [
+  "Needs Analysis",
+  "Objective",
+  "Final Assessment Strategy",
+  "Course Structure",
+  "Course Strategy Document",
+  "Storyboard",
+];
+
+const MenuBlock = ({ step, state }) => {
+  const className = "menu-step " + state;
+  const key = step.split(" ").join("_");
+  return (
+    <li key={key} className={className}>
+      {step}
+      {state === "completed" && (
+        <img
+          src={TickCircleSolid}
+          alt="Green Tick Icon"
+          className="green-tick"
+        />
+      )}
+    </li>
+  );
+};
+
+const StepsMenu = ({ currentStep }) => {
+  let state = "completed";
+
+  const menu = MENU_STEPS.map((step) => {
+    if (step === currentStep) {
+      state = "next";
+      return <MenuBlock step={step} state="current" />;
+    } else {
+      return <MenuBlock step={step} state={state} />;
+    }
+  });
+
+  return <ul className="isd-flow-steps-menu">{menu}</ul>;
+};
+
+export default StepsMenu;

--- a/isd-app/src/utilities/isdPagesLogic/stepsMenu/StepsMenu.scss
+++ b/isd-app/src/utilities/isdPagesLogic/stepsMenu/StepsMenu.scss
@@ -1,0 +1,33 @@
+@import '../../../styles/variables';
+
+.isd-flow-steps-menu {
+    flex: 0 1 25%;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0;
+    
+
+    .menu-step {
+        padding: 2.1875rem 1.5rem;
+        font-weight: $fontWeightBold;
+        font-size: $font-size-half-regular;
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .current {
+        background-color: $current-menu-step-background;
+    }
+
+    .next {
+        background-color: $next-menu-step-background;
+    }
+
+    .completed {
+        background-color: $completed-menu-step-background;
+    }
+
+
+}

--- a/isd-app/src/utilities/utils.jsx
+++ b/isd-app/src/utilities/utils.jsx
@@ -1,68 +1,81 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
 export const MyInput = React.forwardRef(
-	({ name, id, type, label, ...rest }, ref) => {
-		return (
-			<div className='form-input'>
-				<label htmlFor={id ?? name}>{label}</label>
-				<input
-					type={type}
-					id={id ?? name}
-					name={name}
-					{...rest}
-					ref={ref}
-				/>
-			</div>
-		);
-	},
+  ({ name, id, type, label, ...rest }, ref) => {
+    return (
+      <div className="form-input">
+        <label htmlFor={id ?? name}>{label}</label>
+        <input type={type} id={id ?? name} name={name} {...rest} ref={ref} />
+      </div>
+    );
+  }
 );
 
-MyInput.displayName = 'MyInput';
+MyInput.displayName = "MyInput";
 
 MyInput.propTypes = {
-	name: PropTypes.string.isRequired,
-	type: PropTypes.string.isRequired,
-	label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
 };
 
 export const MySelect = React.forwardRef(
-	({ name, id, label, options, ...rest }, ref) => {
-		return (
-			<div className='form-input'>
-				<label htmlFor={id ?? name}>{label}</label>
-				<select
-					className='role-selector'
-					defaultValue={options[0].label}
-					id={id ?? name}
-					name={name}
-					{...rest}
-					ref={ref}>
-					{options.map((option, index) => (
-						<option
-							key={option.value}
-							value={option.label}
-							disabled={
-								index === 0 || option.value === 'Select role'
-							}>
-							{option.label}
-						</option>
-					))}
-				</select>
-			</div>
-		);
-	},
+  ({ name, id, label, options, ...rest }, ref) => {
+    return (
+      <div className="form-input">
+        <label htmlFor={id ?? name}>{label}</label>
+        <select
+          className="role-selector"
+          defaultValue={options[0].label}
+          id={id ?? name}
+          name={name}
+          {...rest}
+          ref={ref}
+        >
+          {options.map((option, index) => (
+            <option
+              key={option.value}
+              value={option.label}
+              disabled={index === 0 || option.value === "Select role"}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
 );
 
-MySelect.displayName = 'MySelect';
+MySelect.displayName = "MySelect";
 
 MySelect.propTypes = {
-	name: PropTypes.string.isRequired,
-	label: PropTypes.string.isRequired,
-	options: PropTypes.arrayOf(
-		PropTypes.shape({
-			value: PropTypes.string.isRequired,
-			label: PropTypes.string.isRequired,
-		}),
-	).isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+};
+
+export const MyTextArea = React.forwardRef(
+  ({ name, id, label, rows, ...rest }, ref) => {
+    return (
+      <div className="form-input">
+        <label htmlFor={id ?? name}>{label}</label>
+        <textarea id={id ?? name} name={name} rows={rows} {...rest} ref={ref} />
+      </div>
+    );
+  }
+);
+
+MyTextArea.displayName = "MyTextArea";
+
+MyTextArea.propTypes = {
+  name: PropTypes.string.isRequired,
+  rows: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
* added routes
* created structure for the page
* added steps menu
* made steps menu reusable for future pages in isd flow
* added project info block to the page
* refactoring: moved common ISD Flow page logic to separate files
* added fields to the form
* added buttons to the form


**A question about implementation strategy:**
I have a question about how we should organize the ISD Flow pages. At the beginning I thought that every page in ISD Flow will have its separate route: a separate URL for the Needs Analysis Page, a separate URL for Objective page and so on. And my implementation is based on this approach. Also I can see that half of the information is repeated on every page (the ISD Flow Steps, The Info about The project and the Project Name). So it makes sense to implement it only once and then reuse across the pages, changing only the form part.
Another approach that came to my mind at the very end is: to have one URL for the whole ISD Flow process. By clicking next button, we can re-render the appropriate form and change the menu step accordingly and that's it.
Which one are we going to stick to?


Created UI for the Needs Analysis Page in ISD Flow:
<img width="1008" alt="Screenshot 2024-01-18 at 9 15 03 PM" src="https://github.com/Alforoan/ISDFE/assets/9776049/84552a59-e6d5-4772-b7fb-965f0328041b">

Also I implemented the Steps Menu the way it will display the correct step for the future pages:
<img width="530" alt="Screenshot 2024-01-18 at 9 35 59 PM" src="https://github.com/Alforoan/ISDFE/assets/9776049/a2505ea4-e241-40fc-b770-c00750599945">
All you need to do is to define the current step and to pass it to ISDFlowPage Component (like in NeedAnalysis.jsx file)



TODO:
- validations (need to figure out what the validations are)
- need to fetch data from the server (now it's all static info)
- figure out how the page should look like on smaller screens. Add media queries for it if needed