### PR TITLE
* reset fields on cancel

### DIFF
--- a/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.jsx
+++ b/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.jsx
@@ -7,14 +7,18 @@ import { MyInput, MyTextArea } from "../../../utilities/utils";
 
 const errorSchema = yup.object({}).required();
 
-const submitNeedsAnalysisForm = async (data) => {
-  console.log(data);
-};
-
 const NeedsAnalysisForm = ({ currentStep }) => {
-  const { register, handleSubmit } = useForm({
+  const { register, handleSubmit, reset } = useForm({
     resolver: yupResolver(errorSchema),
   });
+
+  const submitNeedsAnalysisForm = async (data) => {
+    console.log(data);
+  };
+
+  const handleCancelClick = () => {
+    reset();
+  };
 
   return (
     <form
@@ -163,7 +167,13 @@ const NeedsAnalysisForm = ({ currentStep }) => {
       </fieldset>
       <div className="button-container">
         <button className="button next">Next</button>
-        <button className="button cancel">Cancel</button>
+        <button
+          className="button cancel"
+          type="button"
+          onClick={handleCancelClick}
+        >
+          Cancel
+        </button>
       </div>
     </form>
   );

--- a/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.scss
+++ b/isd-app/src/pages/ISDFlow/NeedsAnalysis/NeedsAnalysis.scss
@@ -72,10 +72,18 @@
         }
         .cancel {
             background-color: $form-white-background;
+
+            &:hover {
+                border-color: $current-menu-step-background;
+            }
         }
         .next {
             color: $font-color-white;
             background-color: $button-blue-background;
+
+            &:hover {
+					background-color: darken($button-blue-background, 10%);
+				}
         }
     }
 }

--- a/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.jsx
+++ b/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.jsx
@@ -7,12 +7,14 @@ const ISDFlowPage = ({ currentStep, children }) => {
   const courseName = "Reducing issues in manufacturing workflow";
 
   return (
-    <div className="isd-flow-container">
-      <h3 className="isd-flow-title">Course name: {courseName}</h3>
-      <div className="isd-flow-content">
-        <StepsMenu currentStep={currentStep} />
-        <div className="isd-flow-form-container">{children}</div>
-        <ProjectInfo />
+    <div className="isd-flow-wrapper">
+      <div className="isd-flow-container">
+        <h3 className="isd-flow-title">Course name: {courseName}</h3>
+        <div className="isd-flow-content">
+          <StepsMenu currentStep={currentStep} />
+          <div className="isd-flow-form-container">{children}</div>
+          <ProjectInfo />
+        </div>
       </div>
     </div>
   );

--- a/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.scss
+++ b/isd-app/src/utilities/isdPagesLogic/isdFlowPage/ISDFlowPage.scss
@@ -1,28 +1,61 @@
 @import '../../../styles/variables';
 
-.isd-flow-container {
-    display: flex;
+.isd-flow-wrapper {
     color: $font-color-black;
-    flex-direction: column;
-    padding: 3rem 5rem;
     font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
 	height: 100%;
 	width: 100vw;
     background-color: $default-background;
-    gap: 2.1875rem;
 
-    .isd-flow-title {
-        font-weight: $fontWeightBold;
-        font-size: $font-size-large;
-    }
 
-    .isd-flow-content {
+    .isd-flow-container {
         display: flex;
-        gap: 1.25rem;
+        flex-direction: column;
+        gap: 2.1875rem;
+        width: 80%;
+        margin: auto;
+        padding-top: 2rem;
 
-        .isd-flow-form-container {
-            flex: 0 1 55%;
+        .isd-flow-title {
+            font-weight: $fontWeightBold;
+            font-size: $font-size-large;
         }
+
+        .isd-flow-content {
+            display: flex;
+            gap: 1.25rem;
+
+            .isd-flow-form-container {
+                flex: 0 1 55%;
+            }
+        }
+    }
+    
+}
+
+@media (max-width: 96rem) {
+    .isd-flow-wrapper {
+        .isd-flow-container {
+            gap: 2rem;
+    
+            .isd-flow-content {
+                gap: 1rem;
+            }
+        }
+        
     }
 }
 
+@media (max-width: 79rem) {
+    .isd-flow-wrapper {
+        .isd-flow-container {
+            gap: 1.5rem;
+            width: 90%;
+    
+            .isd-flow-content {
+                gap: 0.7rem;
+            }
+        }
+        
+    }
+}

--- a/isd-app/src/utilities/isdPagesLogic/stepsMenu/StepsMenu.scss
+++ b/isd-app/src/utilities/isdPagesLogic/stepsMenu/StepsMenu.scss
@@ -31,3 +31,9 @@
 
 
 }
+
+@media (max-width: 79rem) {
+    .isd-flow-steps-menu {
+        gap: 0.7rem;
+    }
+}


### PR DESCRIPTION
* reset fields on cancel
* adjusted content layout for smaller screens
* for larger screens content width is 80%
* for smaller screens content width is 90%

Some screenshots for various screen sizes:
<img width="1169" alt="Screenshot 2024-01-27 at 12 41 05 PM" src="https://github.com/Alforoan/ISDFE/assets/9776049/4780c69b-3cd1-4ef6-8e7d-4f6a2ce7b8c9">
<img width="1002" alt="Screenshot 2024-01-27 at 12 41 26 PM" src="https://github.com/Alforoan/ISDFE/assets/9776049/ea3b11d0-a445-4176-bd52-e9dd0be89678">
<img width="823" alt="Screenshot 2024-01-27 at 12 41 42 PM" src="https://github.com/Alforoan/ISDFE/assets/9776049/ba477838-c93c-4209-adef-90e178946d77">
<img width="613" alt="Screenshot 2024-01-27 at 12 41 55 PM" src="https://github.com/Alforoan/ISDFE/assets/9776049/1d6f3cd5-a9e5-4b7c-892a-9b223eb0a4cb">
