### PR TITLE
Adjusted requests table layout for screen width less then 1000px

### DIFF
--- a/isd-app/src/styles/_variables.scss
+++ b/isd-app/src/styles/_variables.scss
@@ -8,14 +8,14 @@ $fontWeightMedium: 500;
 $fontWeightRegular: 400;
 
 // Font Sizes
-$font-size-large: 3rem;
-$font-size-medium: 2rem;
-$font-size-regular: 1.5rem;
-$font-size-half-regular: 1.25rem;
-$font-size-semi-regular: 1.125rem;
-$font-size-small: 1rem;
-$font-size-semi-small: 0.875rem;
-$font-size-extra-small: 0.75rem;
+$font-size-large: 3rem; //48px
+$font-size-medium: 2rem; //32px
+$font-size-regular: 1.5rem; //24px
+$font-size-half-regular: 1.25rem; //20px
+$font-size-semi-regular: 1.125rem; //18px
+$font-size-small: 1rem; //16px
+$font-size-semi-small: 0.875rem; //14px
+$font-size-extra-small: 0.75rem; //12px
 
 @font-face {
 	font-family: 'Inter';

--- a/isd-app/src/utilities/requestsLogic/table/RequestRowSmallScreen.jsx
+++ b/isd-app/src/utilities/requestsLogic/table/RequestRowSmallScreen.jsx
@@ -1,0 +1,22 @@
+import RequestStatus from "./RequestStatus";
+import stages from "./stages";
+import "./RequestRowSmallScreen.scss";
+
+const RequestRowSmallScreen = ({ request }) => {
+  return (
+    <div className="request-row-small">
+      <div className="request-name">{request.requestName}</div>
+      <div className="status">
+        <RequestStatus status={request.status} />
+      </div>
+      <div className="assigned-to-header">Assigned to</div>
+      <div className="assigned-to">{request.assignedTo}</div>
+      <div className="stage-header">Stage</div>
+      <div className="stage">{stages[request.stage]}</div>
+      <div className="last-updated-header">Last updated</div>
+      <div className="last-updated">{request.lastUpdated}</div>
+    </div>
+  );
+};
+
+export default RequestRowSmallScreen;

--- a/isd-app/src/utilities/requestsLogic/table/RequestRowSmallScreen.scss
+++ b/isd-app/src/utilities/requestsLogic/table/RequestRowSmallScreen.scss
@@ -1,0 +1,66 @@
+@import "./../../../styles/variables";
+
+.request-row-small {
+    background-color: $form-white-background;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    padding: 2.25rem 2.5rem;
+    border-bottom: 1px solid $border-color;
+
+    &:first-child {
+        margin-top: 2.5rem;
+    }
+
+    .request-name {
+        grid-column: 1 / span 3;
+        font-weight: $fontWeightSemiBold;
+        font-size: $font-size-half-regular;
+    }
+    .status {
+        justify-self: end;
+    }
+    .assigned-to, .stage {
+        grid-column: 2 / span 3;
+    }
+    .last-updated-header, .last-updated {
+        grid-column: 1 / span 4;
+    }
+
+    .assigned-to-header {
+        padding-top: 2.5rem;
+    }
+
+    .assigned-to {
+        padding-top: 2.5rem;
+    }
+
+    .stage-header {
+        padding-top: 0.75rem;
+    }
+
+    .stage {
+        padding-top: 0.75rem;
+    }
+
+    .last-updated-header {
+        padding-top: 3.4rem;
+        font-weight: $fontWeightMedium;
+        font-size: $font-size-extra-small;
+    }
+
+    .assigned-to-header, .stage-header {
+        font-weight: $fontWeightRegular;
+        font-size: $font-size-semi-small;
+    }
+
+    .assigned-to, .stage {
+        font-weight: $fontWeightSemiBold;
+        font-size: $font-size-semi-small;
+    }
+
+    .last-updated {
+        padding-top: 0.75rem;
+        font-weight: $fontWeightSemiBold;
+        font-size: $font-size-small;
+    }
+}

--- a/isd-app/src/utilities/requestsLogic/table/RequestStatus.scss
+++ b/isd-app/src/utilities/requestsLogic/table/RequestStatus.scss
@@ -6,6 +6,7 @@
 
     font-weight: $fontWeightSemiBold;
     font-size: $font-size-extra-small;
+    display: inline-block;
 }
 
 .grey {

--- a/isd-app/src/utilities/requestsLogic/table/RequestsTable.jsx
+++ b/isd-app/src/utilities/requestsLogic/table/RequestsTable.jsx
@@ -1,5 +1,7 @@
 import "./RequestsTable.scss";
 import RequestRow from "./RequestRow";
+import RequestRowSmallScreen from "./RequestRowSmallScreen";
+import { useState, useEffect } from "react";
 
 const info = [
   {
@@ -32,8 +34,30 @@ const info = [
   },
 ];
 
-
 const RequestsTable = () => {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  if (width < 1000) {
+    return (
+      <section className="requests-table-small">
+        {info.map((request, index) => (
+          <RequestRowSmallScreen key={index} request={request} />
+        ))}
+      </section>
+    );
+  }
   return (
     <table className="requests-table">
       <thead className="requests-table-header">

--- a/isd-app/src/utilities/requestsLogic/table/RequestsTable.scss
+++ b/isd-app/src/utilities/requestsLogic/table/RequestsTable.scss
@@ -5,7 +5,7 @@
     table-layout: fixed;
     width: 100%;
     border-collapse: collapse;
-    margin-top: 2.5rem;;
+    margin-top: 2.5rem;
 
     .requests-table-header {
         th {


### PR DESCRIPTION
For screen width less then 1000px, the the table with requests will look the following way:

<img width="457" alt="Screenshot 2024-06-11 at 7 38 41 PM" src="https://github.com/Alforoan/ISDFE/assets/9776049/194d488f-f7df-45a9-b5c8-b2d56a15d651">
